### PR TITLE
Added semantic checking for multiple H1 elements.

### DIFF
--- a/AccessibilityChecker/HeadingChecker.cs
+++ b/AccessibilityChecker/HeadingChecker.cs
@@ -57,10 +57,24 @@ namespace AccessibilityChecker
 
         public string HeadingOneCheck(HtmlDocument doc)
         {
-            //Check if Heading1 is first
+            // If there is more than a single H1 element, check to see if the others are semantic.
             if (HeadingOneList.Count > 1)
             {
-                return "Please Fix, There Should be 1 HeadingOne";
+                for (var i = 1; i < HeadingOneList.Count; i++)
+                {   
+                    HtmlNode HeadingOne = doc.DocumentNode.SelectSingleNode(HeadingOneList[i].XPath + "/parent::node()");
+
+                    // This can be expanded to check if 'header' is used in the correct context - i.e inside of an article.
+                    if (HeadingOne.Name.Contains("article") || HeadingOne.Name.Contains("section") || HeadingOne.Name.Contains("header"))
+                    {
+                        Console.WriteLine(HeadingOneList[i].InnerText + " - H1 is semantic.");
+                    }
+                    else
+                    {
+                        Console.WriteLine(HeadingOneList[i].InnerText + " - H1 is not semantic.");
+                    }
+                }
+                return "Multiple H1 elements found & checked for semantics.";
             }
             else
             {


### PR DESCRIPTION
Fix for issue #6. As per the comments in the code, this statement could be further extended depending on how through we want to be when checking for semantics.

Once PR #5 is merged, the method PageHeadings could be expanded in order to include this information in the report file.

Documentation reviewed to implement this code can be found [here](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines).